### PR TITLE
show separate usr/sys cpu numbers

### DIFF
--- a/docs/main.js
+++ b/docs/main.js
@@ -151,34 +151,74 @@ let columnDefs = [
         ]
     },
     {
-        headerName: "CPU (total usage)", children: [
+        headerName: "CPU (system)", children: [
             {
-                headerName: "Max", field: "cpu.max",
+                headerName: "Max", field: "sys.max",
                 filter: 'agNumberColumnFilter', hide: true, valueFormatter: cpuFormatter
             },
             {
-                headerName: "Mean", field: "cpu.mean",
+                headerName: "Mean", field: "sys.mean",
                 filter: 'agNumberColumnFilter', valueFormatter: cpuFormatter
             },
             {
-                headerName: "% max mean", field: "cpu.mean",
-                filter: false, sortable: false, colId: "percent_max_mean_cpu_bar",
+                headerName: "% max mean", field: "sys.mean",
+                filter: false, sortable: false, colId: "percent_max_mean_sys_bar",
                 cellRenderer: 'percentBarCellRenderer', width: 200
             },
             {
-                headerName: "Median", field: "cpu.median",
+                headerName: "Median", field: "sys.median",
                 filter: 'agNumberColumnFilter', hide: true, valueFormatter: cpuFormatter
             },
             {
-                headerName: "Stdev", field: "cpu.stdev",
+                headerName: "Stdev", field: "sys.stdev",
                 filter: 'agNumberColumnFilter', hide: true, valueFormatter: cpuFormatter
             },
             {
-                headerName: "Stdev range", field: "cpu.stdev_range",
+                headerName: "Stdev range", field: "sys.stdev_range",
                 filter: 'agNumberColumnFilter', hide: true, valueFormatter: cpuFormatter
             },
             {
                 headerName: "Threads", field: "threads", hide: true
+            }
+        ]
+    },
+    {
+        headerName: "CPU (user)", children: [
+            {
+                headerName: "Max", field: "usr.max",
+                filter: 'agNumberColumnFilter', hide: true, valueFormatter: cpuFormatter
+            },
+            {
+                headerName: "Mean", field: "usr.mean",
+                filter: 'agNumberColumnFilter', valueFormatter: cpuFormatter
+            },
+            {
+                headerName: "% max mean", field: "usr.mean",
+                filter: false, sortable: false, colId: "percent_max_mean_usr_bar",
+                cellRenderer: 'percentBarCellRenderer', width: 200
+            },
+            {
+                headerName: "Median", field: "usr.median",
+                filter: 'agNumberColumnFilter', hide: true, valueFormatter: cpuFormatter
+            },
+            {
+                headerName: "Stdev", field: "usr.stdev",
+                filter: 'agNumberColumnFilter', hide: true, valueFormatter: cpuFormatter
+            },
+            {
+                headerName: "Stdev range", field: "usr.stdev_range",
+                filter: 'agNumberColumnFilter', hide: true, valueFormatter: cpuFormatter
+            },
+            {
+                headerName: "Threads", field: "threads", hide: true
+            }
+        ]
+    },
+    {
+        headerName: "CPU (total)", children: [
+            {
+                headerName: "Mean", field: "cpu.mean",
+                filter: 'agNumberColumnFilter', valueFormatter: cpuFormatter
             }
         ]
     },
@@ -308,8 +348,10 @@ function PercentBarCellRenderer() { }
             maxThing = window.TFB_GRID.minMaxes.meanLat90;
         else if (params.colDef.field.indexOf("memory.") === 0)
             maxThing = window.TFB_GRID.minMaxes.maxMem;
-        else if (params.colDef.field.indexOf("cpu.") === 0)
-            maxThing = window.TFB_GRID.minMaxes.maxCpu;
+        else if (params.colDef.field.indexOf("usr.") === 0)
+            maxThing = window.TFB_GRID.minMaxes.maxUsr;
+        else if (params.colDef.field.indexOf("sys.") === 0)
+            maxThing = window.TFB_GRID.minMaxes.maxSys;
 
         let percent = maxThing <= 0 ? 0 : 100 * value / maxThing;
         let eDivPercentBarWrapper = document.createElement('div');
@@ -428,12 +470,13 @@ window.TFB_GRID = {
         }
 
         function calculateMinMaxes(fetchedData) {
-            let maxRps = 0, sumLat90 = 0, countLat90 = 0, maxMem = 0, maxCpu = 0;
+            let maxRps = 0, sumLat90 = 0, countLat90 = 0, maxMem = 0, maxSys = 0, maxUsr = 0;
             for (let i = 0; i < fetchedData.length; i++) {
                 let fw = fetchedData[i];
                 if (fw.rps.requests_per_sec > maxRps) maxRps = fw.rps.requests_per_sec;
                 if (fw.memory.max > maxMem) maxMem = fw.memory.max;
-                if (fw.cpu.max > maxCpu) maxCpu = fw.cpu.max;
+                if (fw.usr.max > maxUsr) maxUsr = fw.usr.max;
+                if (fw.sys.max > maxSys) maxSys = fw.sys.max;
                 if (fw.latency.lat90 > 0) {
                     countLat90 += 1;
                     sumLat90 += fw.latency.lat90;
@@ -444,7 +487,8 @@ window.TFB_GRID = {
                 maxRps: maxRps,
                 meanLat90: sumLat90 / countLat90,
                 maxMem: maxMem,
-                maxCpu: maxCpu
+                maxSys: maxSys,
+                maxUsr: maxUsr,
             };
         }
 


### PR DESCRIPTION
- the current cpu shown is just user time
- this PR will show both urs and sys time in separate columns and a total cpu time in another column

![Screenshot from 2020-10-12 03-10-30](https://user-images.githubusercontent.com/159073/95698033-8ee4e700-0c38-11eb-8583-2307bc4e6d15.png)
